### PR TITLE
fix: breakage with Node v9.4.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,13 @@ workflows:
   version: 2
   tests:
     jobs:
-      - node8:
-          filters: *release_tags
+      # - node8:
+      #     filters: *release_tags
       - node9:
           filters: *release_tags
       - publish_npm:
           requires:
-            - node8
+            # - node8
             - node9
           filters:
             branches:
@@ -37,11 +37,11 @@ workflows:
             <<: *release_tags
 
 jobs:
-  node8:
-    docker:
-      - image: node:8
-        user: node
-    <<: *unit_tests
+  # node8:
+  #   docker:
+  #     - image: node:8
+  #       user: node
+  #   <<: *unit_tests
   node9:
     docker:
       - image: node:9
@@ -50,7 +50,7 @@ jobs:
 
   publish_npm:
     docker:
-      - image: node:8
+      - image: node:9
         user: node
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This library assumes that the middlewares built on top of it act as a static
 file server. That is because static file serving is one of the most common
 use cases for HTTP/2 server push.
 
+**This package currently works only with Node >=9.4.0.**
+
 ## Interface
 
 ### `class AutoPush`

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,12 @@
         "arrify": "1.0.1"
       }
     },
+    "@types/get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==",
+      "dev": true
+    },
     "@types/node": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
@@ -3340,9 +3346,9 @@
       "dev": true
     },
     "js-green-licenses": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.3.1.tgz",
-      "integrity": "sha512-pFWoi11NZuQPt0emRrQKVi+DVjLUYSE+v/cbMzWIrce+2CvkQ5PQUHwJwXua835Q4RpJMe2BxR66VU7BC1Tusg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/js-green-licenses/-/js-green-licenses-0.4.0.tgz",
+      "integrity": "sha512-LpkL/9coWxNUmJ9/jxng3uvcLK6Qso2yaz7QBjO+atwtX/xmt8MrCtbkolYdhPZl/fq5dRs7Q7BLA8Ne3DKZ2w==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,12 @@
       "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.4.0.tgz",
+      "integrity": "sha512-PBHCvO98hNec9A491vBbh0ZNDOVxccwKL1u2pm6fs9oDgm7SEnw0lEHqHfjsYryDxnE3zaf7LvERWEXjOp1hig==",
+      "dev": true
+    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -325,7 +331,7 @@
         "require-precompiled": "0.1.0",
         "resolve-cwd": "2.0.0",
         "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "slash": "1.0.0",
         "source-map-support": "0.5.0",
         "stack-utils": "1.0.1",
@@ -1229,7 +1235,7 @@
         "lodash.flattendeep": "4.4.0",
         "lodash.merge": "4.6.0",
         "md5-hex": "2.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "well-known-symbols": "1.0.0"
       }
     },
@@ -3891,7 +3897,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -3912,7 +3918,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "osenv": "0.1.4",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-name": "3.0.0"
       }
     },
@@ -5664,7 +5670,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "parse-glob": {
@@ -6188,10 +6194,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -6199,7 +6204,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "set-immediate-shim": {
@@ -6637,7 +6642,7 @@
         "js-yaml": "3.10.0",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "tslib": "1.8.1",
         "tsutils": "2.18.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6202,7 +6202,8 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -45,12 +45,14 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
+    "@types/get-port": "^3.2.0",
     "@types/node": "^9.3.0",
     "@types/semver": "^5.4.0",
     "ava": "^0.24.0",
     "codecov": "^3.0.0",
+    "get-port": "^3.2.0",
     "gts": "^0.5.3",
-    "js-green-licenses": "^0.3.1",
+    "js-green-licenses": "^0.4.0",
     "nyc": "^11.4.1",
     "typescript": "~2.6.2"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "posttest": "npm run check && npm run license-check",
     "license-check": "jsgl --local ."
   },
+  "engines": {
+    "node": ">=9.4.0 || >8.9.4 <9"
+  },
   "keywords": [
     "http2",
     "auto-push",
@@ -41,8 +44,7 @@
     ]
   },
   "dependencies": {
-    "bloomfilter": "^0.0.16",
-    "semver": "^5.5.0"
+    "bloomfilter": "^0.0.16"
   },
   "devDependencies": {
     "@types/get-port": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,12 @@
     ]
   },
   "dependencies": {
-    "bloomfilter": "^0.0.16"
+    "bloomfilter": "^0.0.16",
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",
+    "@types/semver": "^5.4.0",
     "ava": "^0.24.0",
     "codecov": "^3.0.0",
     "gts": "^0.5.3",

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -127,17 +127,18 @@ export class AutoPush {
               });
         };
         // Node 9.4.0 changed the callback function signature.
-        const callback: PushStreamCallback = isNode940 ?
-            ((err: Error, pushStream: http2.ServerHttp2Stream):
-                 void => {
-                   if (err) {
-                     return reject(err);
-                   }
-                   pushFile(pushStream);
-                 }) as Function as PushStreamCallback :
-            (pushStream) => {
-              pushFile(pushStream);
-            };
+        let callback: PushStreamCallback;
+        if (isNode940) {
+          callback =
+              ((err: Error, pushStream: http2.ServerHttp2Stream): void => {
+                if (err) {
+                  return reject(err);
+                }
+                pushFile(pushStream);
+              }) as Function as PushStreamCallback;
+        } else {
+          callback = pushFile;
+        }
 
         stream.pushStream({':path': asset}, callback);
       });

--- a/ts/test/index-test.ts
+++ b/ts/test/index-test.ts
@@ -1,0 +1,111 @@
+import test from 'ava';
+import * as http2 from 'http2';
+import * as path from 'path';
+
+import {AutoPush} from '../src/index';
+
+function staticFilePath(filePath: string): string {
+  return path.join(__dirname, '..', '..', 'ts', 'test', 'static', filePath);
+}
+
+function startServer() {
+  const ap = new AutoPush(staticFilePath(''));
+  const server = http2.createServer();
+  server
+      .on('error',
+          (err) => {
+            throw err;
+          })
+      .on('socketError',
+          (err) => {
+            throw err;
+          })
+      .on('stream', async (stream, headers) => {
+        const reqPath = headers[':path'] as string;
+        await ap.preprocessRequest(reqPath, stream);
+        await ap.push(stream);
+        switch (reqPath) {
+          case '/foo.html':
+            stream.respondWithFile(staticFilePath('foo.html'));
+            break;
+          case '/bar.html':
+            stream.respondWithFile(staticFilePath('bar.html'));
+            break;
+          default:
+            throw new Error(`Unexpected path: ${reqPath}`);
+        }
+        ap.recordRequestPath(stream.session, reqPath, true);
+      });
+  server.listen(8443);
+}
+
+interface ClientData {
+  data: string;
+  pushedPaths: string[];
+}
+
+function request(
+    session: http2.ClientHttp2Session, reqPath: string): Promise<ClientData> {
+  const result: ClientData = {
+    data: '',
+    pushedPaths: [],
+  };
+  return new Promise((resolve) => {
+    session
+        .on('error',
+            (err) => {
+              throw err;
+            })
+        .on('socketError',
+            (err) => {
+              throw err;
+            })
+        .on('stream', (pushedStream, headers) => {
+          result.pushedPaths.push(headers[':path'] as string);
+        });
+    const clientStream = session.request({':path': reqPath});
+    clientStream.setEncoding('utf8');
+    let data = '';
+    clientStream
+        .on('data',
+            (chunk) => {
+              data += chunk;
+            })
+        .on('end', () => {
+          result.data = data;
+          resolve(result);
+        });
+    clientStream.end();
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
+test('basic test', async (t) => {
+  startServer();
+
+  // Request /foo.html and /bar.html so that /bar.html is pushed when /foo.html
+  // is requested in a following session.
+  const client1 = http2.connect('http://localhost:8443');
+  const fooData = await request(client1, '/foo.html');
+  t.true(fooData.data.includes('This is a foo document.'));
+  t.is(fooData.pushedPaths.length, 0);
+  const barData = await request(client1, '/bar.html');
+  t.true(barData.data.includes('This is a bar document.'));
+  t.is(barData.pushedPaths.length, 0);
+
+  // Delay so that the next request is not part of the warming up.
+  await delay(1000);
+
+  // Request /foo.html and see /bar.html is pushed.
+  const client2 = http2.connect('http://localhost:8443');
+  const fooData2 = await request(client2, '/foo.html');
+  t.true(fooData2.data.includes('This is a foo document.'));
+  t.deepEqual(fooData2.pushedPaths, ['/bar.html']);
+});

--- a/ts/test/static/bar.html
+++ b/ts/test/static/bar.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bar Document</title>
+</head>
+<body>
+  This is a bar document.
+</body>
+</html>

--- a/ts/test/static/foo.html
+++ b/ts/test/static/foo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Foo Document</title>
+</head>
+<body>
+  This is a foo document.
+</body>
+</html>


### PR DESCRIPTION
`pushStream()`'s callback has changed from `(pushedStream, headers) =>
{}` to `(err, pushedStream, headers) => {}` with Node v9.4.0.