### PR TITLE
chore: release v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h2-auto-push",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "HTTP/2 auto-push library",
   "main": "build/src/index.js",
   "types": "build/src/index",


### PR DESCRIPTION
Support only Node ">=9.4.0" or ">8.9.4 <9".

The draft release note is in the GitHub UI.