### PR TITLE
feat: pushList must be per request, not per object

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ file server. That is because static file serving is one of the most common
 use cases for HTTP/2 server push.
 
 See https://github.com/google/node-fastify-auto-push for an example. It is a
-fastify plugin for supporting auto-push.
+[fastify](https://www.fastify.io/) plugin for supporting auto-push.
 
 **This package currently works only with Node >=9.4.0.**
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -34,9 +34,13 @@ const DEFAULT_CACHE_CONFIG: AssetCacheConfig = {
   minimumRequests: 1,
 };
 
+export interface PreprocessResult {
+  newCacheCookie: string;
+  pushFn: (stream: http2.ServerHttp2Stream) => Promise<void>;
+}
+
 export class AutoPush {
   private readonly assetCache: AssetCache;
-  private pushList: string[] = [];
 
   constructor(
       private readonly rootDir: string,
@@ -57,7 +61,7 @@ export class AutoPush {
 
   async preprocessRequest(
       reqPath: string, stream: http2.ServerHttp2Stream,
-      cacheCookie?: string): Promise<string> {
+      cacheCookie?: string): Promise<PreprocessResult> {
     const cacheChecker = cacheCookie ?
         ClientCacheChecker.deserialize(cacheCookie) :
         new ClientCacheChecker();
@@ -65,10 +69,13 @@ export class AutoPush {
     // set the bloom filter cookie correctly that contains the auto-pushed
     // assets as well as the original asset. Otherwise we'll auto-push assets
     // that browser already has in future responses.
-    this.pushList = await this.getAutoPushList(reqPath, stream, cacheChecker);
+    const pushList = await this.getAutoPushList(reqPath, stream, cacheChecker);
     cacheChecker.addPath(reqPath);
-    const cacheCookieValue = cacheChecker.serialize();
-    return cacheCookieValue;
+    const newCacheCookie = cacheChecker.serialize();
+    return {
+      newCacheCookie,
+      pushFn: async (stream) => await this.push(stream, pushList),
+    };
   }
 
   private async getAutoPushList(
@@ -106,8 +113,9 @@ export class AutoPush {
     return result;
   }
 
-  async push(stream: http2.ServerHttp2Stream): Promise<void> {
-    const pushPromises = this.pushList.map((asset): Promise<void> => {
+  private async push(stream: http2.ServerHttp2Stream, pushList: string[]):
+      Promise<void> {
+    const pushPromises = pushList.map((asset): Promise<void> => {
       return new Promise((resolve, reject) => {
         const pushFile = (pushStream: http2.ServerHttp2Stream): void => {
           pushStream.on('finish', () => {
@@ -135,7 +143,6 @@ export class AutoPush {
             }) as Function as PushStreamCallback);
       });
     });
-    this.pushList = [];
     await Promise.all(pushPromises);
   }
 }

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -74,7 +74,7 @@ export class AutoPush {
     const newCacheCookie = cacheChecker.serialize();
     return {
       newCacheCookie,
-      pushFn: async (stream) => await this.push(stream, pushList),
+      pushFn: (stream) => this.push(stream, pushList),
     };
   }
 

--- a/ts/test/index-test.ts
+++ b/ts/test/index-test.ts
@@ -25,7 +25,7 @@ async function startServer(): Promise<number> {
           })
       .on('stream', async (stream, headers) => {
         const reqPath = headers[':path'] as string;
-        await ap.preprocessRequest(reqPath, stream);
+        const {pushFn} = await ap.preprocessRequest(reqPath, stream);
         switch (reqPath) {
           case '/foo.html':
             stream.respondWithFile(staticFilePath('foo.html'));
@@ -37,7 +37,7 @@ async function startServer(): Promise<number> {
             throw new Error(`Unexpected path: ${reqPath}`);
         }
         ap.recordRequestPath(stream.session, reqPath, true);
-        await ap.push(stream);
+        await pushFn(stream);
       });
   server.listen(port);
   return port;


### PR DESCRIPTION
Currently `pushList` is created and stored as an instance variable from
`preprocessRequest()`. But the list must be created for each request. To
fix that, make `preprocessRequest()` return a push function that is to
be used by the middleware later. And make the `push()` function private.

Also update README about this change. And add a link to
`fastify-auto-push` as an example.