### PR TITLE
feat: emit 'pushError' on errors during push

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ preprocessRequest(
 
 interface PreprocessResult {
   newCacheCookie: string;
-  pushFn: (stream: http2.ServerHttp2Stream) => Promise<void>;
+  pushFn: () => Promise<void>;
 }
 ```
 
@@ -80,9 +80,6 @@ use the `newCacheCookie` value to store it in the browser cookie, and use
 `pushFn` to push static resources that are associated with the current
 request.
 
-*   `stream`: The stream associated with the current request/response. This
-    method will create a new push stream for pushed resources, if any.
-
 This method (and `recordRequestPath()` described below) must be called for
 non-static file requests as well as static files that are being served by the
 middleware. That's because there may be cases where a set of static files
@@ -91,6 +88,10 @@ must be pushed in association with a non-static resource. For example, when
 application, it probably wants to push related resources such as stylesheets,
 images, JavaScript files, etc. that are needed for the browser to render the
 page.
+
+When there is an error while pushing resources, a `'pushError'` will be
+emitted on the parent `stream`, whose argument is an error object that caused
+it.
 
 #### `recordRequestPath()`
 

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -137,7 +137,10 @@ export class AutoPush {
                 statCheck: (stats, headers) => {
                   this.addCacheHeaders(headers, stats);
                 },
-                onError,
+                onError: (err) => {
+                  onError(err);
+                  pushStream.removeListener('error', onError);
+                },
               });
         };
         stream.pushStream(

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -138,8 +138,8 @@ export class AutoPush {
                   this.addCacheHeaders(headers, stats);
                 },
                 onError: (err) => {
-                  onError(err);
                   pushStream.removeListener('error', onError);
+                  onError(err);
                 },
               });
         };

--- a/ts/test/index-test.ts
+++ b/ts/test/index-test.ts
@@ -37,7 +37,7 @@ async function startServer(): Promise<number> {
             throw new Error(`Unexpected path: ${reqPath}`);
         }
         ap.recordRequestPath(stream.session, reqPath, true);
-        await pushFn(stream);
+        await pushFn();
       });
   server.listen(port);
   return port;


### PR DESCRIPTION
The error is emitted on the parent stream.

Also remove the `stream` argument of the `pushFn()` function, which is
redundant.

This is a BREAKING CHANGE due to the `pushFn()` argument change.