### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "h2-auto-push",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "h2-auto-push",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "HTTP/2 auto-push library",
   "main": "build/src/index.js",
   "types": "build/src/index",


### PR DESCRIPTION
Due to a breaking change in https://github.com/google/node-h2-auto-push/pull/13, this is a semver minor.

The draft release note is in https://github.com/google/node-h2-auto-push/releases/tag/untagged-346ab401d07df90de0df